### PR TITLE
Change is_null() to !isset() to avoid PHP exception

### DIFF
--- a/iplocate.php
+++ b/iplocate.php
@@ -44,7 +44,7 @@ class IPLocatePlugin extends Plugin
         require_once __DIR__ . '/classes/ipinfo.class.php';
 
         global $_SERVER;
-        if ( is_null( $ip ) ) {
+        if ( !isset( $ip ) ) {
             $ip = $_SERVER['REMOTE_ADDR'];
         }
 


### PR DESCRIPTION
Fixes issue #1 

In some cases where the $ip variable hasn't been initialized,
iplocations will give a notice exception because is_null() only checks
that the variable is null, but isset() checks that it has been
initialized and is not null.
