### PR TITLE
Feature: Send a custom IP to Geo services

### DIFF
--- a/iplocate.php
+++ b/iplocate.php
@@ -43,9 +43,15 @@ class IPLocatePlugin extends Plugin
         require_once __DIR__ . '/classes/dbip.class.php';
         require_once __DIR__ . '/classes/ipinfo.class.php';
 
-        global $_SERVER;
-        if ( !isset( $ip ) ) {
-            $ip = $_SERVER['REMOTE_ADDR'];
+        //It's possible to specify the ip sent to the APIs,
+        //mainly for test purposes.
+        if ($this->config->get('plugins.iplocate.test_ip')) {
+            $ip = $this->config->get('plugins.iplocate.test_ip');
+        } else {
+            global $_SERVER;
+            if (!isset($ip)) {
+                $ip = $_SERVER['REMOTE_ADDR'];
+            }
         }
 
         /* Standardized field codes:

--- a/iplocate.yaml
+++ b/iplocate.yaml
@@ -6,4 +6,6 @@ sequence:
   - dbip # API key required
 
 keys:
-  dbip: "FAKEKEY"
+   dbip: "FAKEKEY"
+
+test_ip: null


### PR DESCRIPTION
This feature allow admin, developers or content redactor to force the IP
sent to ip geolocation services. This is useful in special cases where
PHP do not receive a proper IP from the client. One could also need to
simulate visits from another geographical region, tests for bugs, etc.